### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "p-timeout": "^4.1.0"
   },
   "devDependencies": {
-    "jest": "^27.0.6"
+    "jest": "^26.6.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,20 +12,20 @@
   "homepage": "https://github.com/financial-times/dj-sheet-reader#readme",
   "dependencies": {
     "abort-controller": "^3.0.0",
-    "commander": "^4.1.1",
+    "commander": "^8.1.0",
     "debug": "^4.3.2",
-    "googleapis": "^60.0.1",
+    "googleapis": "^84.0.0",
     "http-errors": "^1.8.0",
-    "js-yaml": "^3.13.1",
+    "js-yaml": "^4.1.0",
     "lodash.groupby": "^4.6.0",
     "lodash.partition": "^4.6.0",
     "lodash.set": "^4.3.2",
-    "markdown-it": "^10.0.0",
-    "markdown-it-anchor": "^5.2.5",
+    "markdown-it": "^12.2.0",
+    "markdown-it-anchor": "^8.1.2",
     "moment": "^2.29.1",
-    "p-timeout": "^3.2.0"
+    "p-timeout": "^4.1.0"
   },
   "devDependencies": {
-    "jest": "^25.1.0"
+    "jest": "^27.0.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "p-timeout": "^4.1.0"
   },
   "devDependencies": {
-    "jest": "^26.6.3"
+    "jest": "^27.0.6"
   }
 }


### PR DESCRIPTION
Did not update p-timeout because version 5 requires ESM, but everything else is updated and tests pass.