### PR TITLE
chore(build): in CI publish action, use node 18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 18
       - name: Install dependencies
         run: npm ci
       - name: Verify


### PR DESCRIPTION
Because semantic-release requires Node 18 in the CI environment where it's being run.