### PR TITLE
test: dont test Node 12

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
It's unlikely an application will use Node 12 as it's well past end of life now. It probably still works but we're no longer testing it.